### PR TITLE
Fixed negative tests error reply comparison

### DIFF
--- a/NRedisTimeSeries.Test/TestAPI/TestAdd.cs
+++ b/NRedisTimeSeries.Test/TestAPI/TestAdd.cs
@@ -110,9 +110,9 @@ namespace NRedisTimeSeries.Test.TestAPI
             double value = 1.1;
             IDatabase db = redisFixture.Redis.GetDatabase();
             var ex = Assert.Throws<RedisServerException>(() => db.TimeSeriesAdd(key, "+", value));
-            Assert.Equal("TSDB: invalid timestamp", ex.Message);
+            Assert.Equal("ERR TSDB: invalid timestamp", ex.Message);
             ex = Assert.Throws<RedisServerException>(() => db.TimeSeriesAdd(key, "-", value));
-            Assert.Equal("TSDB: invalid timestamp", ex.Message);
+            Assert.Equal("ERR TSDB: invalid timestamp", ex.Message);
         }
     }
 }

--- a/NRedisTimeSeries.Test/TestAPI/TestAddAsync.cs
+++ b/NRedisTimeSeries.Test/TestAPI/TestAddAsync.cs
@@ -116,10 +116,10 @@ namespace NRedisTimeSeries.Test.TestAPI
             var value = 1.1;
             var db = redisFixture.Redis.GetDatabase();
             var ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.TimeSeriesAddAsync(key, "+", value));
-            Assert.Equal("TSDB: invalid timestamp", ex.Message);
+            Assert.Equal("ERR TSDB: invalid timestamp", ex.Message);
 
             ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.TimeSeriesAddAsync(key, "-", value));
-            Assert.Equal("TSDB: invalid timestamp", ex.Message);
+            Assert.Equal("ERR TSDB: invalid timestamp", ex.Message);
         }
     }
 }

--- a/NRedisTimeSeries.Test/TestAPI/TestDecrBy.cs
+++ b/NRedisTimeSeries.Test/TestAPI/TestDecrBy.cs
@@ -85,9 +85,9 @@ namespace NRedisTimeSeries.Test.TestAPI
             double value = 5.5;
             IDatabase db = redisFixture.Redis.GetDatabase();
             var ex = Assert.Throws<RedisServerException>(() => db.TimeSeriesDecrBy(key, value, timestamp: "+"));
-            Assert.Equal("TSDB: invalid timestamp", ex.Message);
+            Assert.Equal("ERR TSDB: invalid timestamp", ex.Message);
             ex = Assert.Throws<RedisServerException>(() => db.TimeSeriesDecrBy(key, value, timestamp: "-"));
-            Assert.Equal("TSDB: invalid timestamp", ex.Message);
+            Assert.Equal("ERR TSDB: invalid timestamp", ex.Message);
         }
     }
 }

--- a/NRedisTimeSeries.Test/TestAPI/TestDecrByAsync.cs
+++ b/NRedisTimeSeries.Test/TestAPI/TestDecrByAsync.cs
@@ -98,10 +98,10 @@ namespace NRedisTimeSeries.Test.TestAPI
             var value = 5.5;
             var db = redisFixture.Redis.GetDatabase();
             var ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.TimeSeriesDecrByAsync(key, value, timestamp: "+"));
-            Assert.Equal("TSDB: invalid timestamp", ex.Message);
+            Assert.Equal("ERR TSDB: invalid timestamp", ex.Message);
 
             ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.TimeSeriesDecrByAsync(key, value, timestamp: "-"));
-            Assert.Equal("TSDB: invalid timestamp", ex.Message);
+            Assert.Equal("ERR TSDB: invalid timestamp", ex.Message);
         }
     }
 }

--- a/NRedisTimeSeries.Test/TestAPI/TestGet.cs
+++ b/NRedisTimeSeries.Test/TestAPI/TestGet.cs
@@ -22,7 +22,7 @@ namespace NRedisTimeSeries.Test.TestAPI
         {
             IDatabase db = redisFixture.Redis.GetDatabase();
             var ex = Assert.Throws<RedisServerException>(()=>db.TimeSeriesGet(key));
-            Assert.Equal("TSDB: the key does not exist", ex.Message);
+            Assert.Equal("ERR TSDB: the key does not exist", ex.Message);
         }
 
         [Fact]

--- a/NRedisTimeSeries.Test/TestAPI/TestGetAsync.cs
+++ b/NRedisTimeSeries.Test/TestAPI/TestGetAsync.cs
@@ -16,7 +16,7 @@ namespace NRedisTimeSeries.Test.TestAPI
             var key = CreateKeyName();
             var db = redisFixture.Redis.GetDatabase();
             var ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.TimeSeriesGetAsync(key));
-            Assert.Equal("TSDB: the key does not exist", ex.Message);
+            Assert.Equal("ERR TSDB: the key does not exist", ex.Message);
         }
 
         [Fact]

--- a/NRedisTimeSeries.Test/TestAPI/TestIncrBy.cs
+++ b/NRedisTimeSeries.Test/TestAPI/TestIncrBy.cs
@@ -85,9 +85,9 @@ namespace NRedisTimeSeries.Test.TestAPI
             double value = 5.5;
             IDatabase db = redisFixture.Redis.GetDatabase();
             var ex = Assert.Throws<RedisServerException>(() => db.TimeSeriesIncrBy(key, value, timestamp: "+"));
-            Assert.Equal("TSDB: invalid timestamp", ex.Message);
+            Assert.Equal("ERR TSDB: invalid timestamp", ex.Message);
             ex = Assert.Throws<RedisServerException>(() => db.TimeSeriesIncrBy(key, value, timestamp: "-"));
-            Assert.Equal("TSDB: invalid timestamp", ex.Message);
+            Assert.Equal("ERR TSDB: invalid timestamp", ex.Message);
         }
     }
 }

--- a/NRedisTimeSeries.Test/TestAPI/TestIncrByAsync.cs
+++ b/NRedisTimeSeries.Test/TestAPI/TestIncrByAsync.cs
@@ -98,10 +98,10 @@ namespace NRedisTimeSeries.Test.TestAPI
             var value = 5.5;
             var db = redisFixture.Redis.GetDatabase();
             var ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.TimeSeriesIncrByAsync(key, value, timestamp: "+"));
-            Assert.Equal("TSDB: invalid timestamp", ex.Message);
+            Assert.Equal("ERR TSDB: invalid timestamp", ex.Message);
 
             ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.TimeSeriesIncrByAsync(key, value, timestamp: "-"));
-            Assert.Equal("TSDB: invalid timestamp", ex.Message);
+            Assert.Equal("ERR TSDB: invalid timestamp", ex.Message);
         }
     }
 }

--- a/NRedisTimeSeries.Test/TestAPI/TestRules.cs
+++ b/NRedisTimeSeries.Test/TestAPI/TestRules.cs
@@ -81,9 +81,9 @@ namespace NRedisTimeSeries.Test.TestAPI
             db.TimeSeriesCreate(destKey);
             TimeSeriesRule rule = new TimeSeriesRule(destKey, 50, Aggregation.AVG);
             var ex = Assert.Throws<RedisServerException>(() => db.TimeSeriesCreateRule(srcKey, rule));
-            Assert.Equal("TSDB: the key does not exist", ex.Message);
+            Assert.Equal("ERR TSDB: the key does not exist", ex.Message);
             ex = Assert.Throws<RedisServerException>(() => db.TimeSeriesDeleteRule(srcKey, destKey));
-            Assert.Equal("TSDB: the key does not exist", ex.Message);
+            Assert.Equal("ERR TSDB: the key does not exist", ex.Message);
         }
 
         [Fact]
@@ -94,9 +94,9 @@ namespace NRedisTimeSeries.Test.TestAPI
             db.TimeSeriesCreate(srcKey);
             TimeSeriesRule rule = new TimeSeriesRule(destKey, 50, Aggregation.AVG);
             var ex = Assert.Throws<RedisServerException>(() => db.TimeSeriesCreateRule(srcKey, rule));
-            Assert.Equal("TSDB: the key does not exist", ex.Message);
+            Assert.Equal("ERR TSDB: the key does not exist", ex.Message);
             ex = Assert.Throws<RedisServerException>(() => db.TimeSeriesDeleteRule(srcKey, destKey));
-            Assert.Equal("TSDB: compaction rule does not exist", ex.Message);
+            Assert.Equal("ERR TSDB: compaction rule does not exist", ex.Message);
         }
     }
 }

--- a/NRedisTimeSeries.Test/TestAPI/TestRulesAsync.cs
+++ b/NRedisTimeSeries.Test/TestAPI/TestRulesAsync.cs
@@ -60,10 +60,10 @@ namespace NRedisTimeSeries.Test.TestAPI
             await db.TimeSeriesCreateAsync(aggKey);
             var rule = new TimeSeriesRule(aggKey, 50, Aggregation.AVG);
             var ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.TimeSeriesCreateRuleAsync(key, rule));
-            Assert.Equal("TSDB: the key does not exist", ex.Message);
+            Assert.Equal("ERR TSDB: the key does not exist", ex.Message);
 
             ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.TimeSeriesDeleteRuleAsync(key, aggKey));
-            Assert.Equal("TSDB: the key does not exist", ex.Message);
+            Assert.Equal("ERR TSDB: the key does not exist", ex.Message);
 
             await db.KeyDeleteAsync(aggKey);
         }
@@ -77,10 +77,10 @@ namespace NRedisTimeSeries.Test.TestAPI
             await db.TimeSeriesCreateAsync(key);
             var rule = new TimeSeriesRule(aggKey, 50, Aggregation.AVG);
             var ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.TimeSeriesCreateRuleAsync(key, rule));
-            Assert.Equal("TSDB: the key does not exist", ex.Message);
+            Assert.Equal("ERR TSDB: the key does not exist", ex.Message);
 
             ex = await Assert.ThrowsAsync<RedisServerException>(async () => await db.TimeSeriesDeleteRuleAsync(key, aggKey));
-            Assert.Equal("TSDB: compaction rule does not exist", ex.Message);
+            Assert.Equal("ERR TSDB: compaction rule does not exist", ex.Message);
         }
     }
 }


### PR DESCRIPTION
This PR fixes the current CI issues around error reply comparison, introduced in https://github.com/RedisTimeSeries/RedisTimeSeries/pull/440